### PR TITLE
Fix/000 metody aktywnego zarzadzania ruchem

### DIFF
--- a/pytania/kti/000-metody-aktywnego-zarzadzania-ruchem.typ
+++ b/pytania/kti/000-metody-aktywnego-zarzadzania-ruchem.typ
@@ -32,11 +32,11 @@ Zarządzanie pasmem to proces kontrolowania i optymalizacji dostępnej przepusto
 
 Przykładowe metody zarządzania pasmem to:
 - *Limitowanie pasma* - pozwala na ograniczanie przepustowości pasma dla konkretnych urządzeń/aplikacji, ogólnie strumieni;
-- *Token Bucket* - to metoda kształtowania ruchu sieciowego, która polega na "wpadaniu" tokenów (żetonów) do ograniczonego pojemnościowo kubełka w stałym tempie. Każdy pakiet danych lub jednostka "pobiera" jeden token, aby zostać przesłany; brak tokenów wstrzymuje ruch lub powoduje jego odrzucenie/opóźnienie, pozwalając na chwilowe "bursty", o ile kubełek jest pełny. Działa to jak bufor, który gromadzi rezerwę na chwilowe skoki obciążenia, zapewniając stabilne średnie natężenie przepływu. Dodatkowo istnieje wariant Hierarchical Token Bucket w którym wiadra mogą mieć rodzciów czy dzieci, który dodatkowo pozwala na "pożyczanie" tokenów od rodzica;
+- *Token Bucket* - to metoda kształtowania ruchu sieciowego, która polega na "wpadaniu" tokenów (żetonów) do ograniczonego pojemnościowo kubełka w stałym tempie. Każdy pakiet danych lub jednostka "pobiera" jeden token, aby zostać przesłany; brak tokenów wstrzymuje ruch lub powoduje jego odrzucenie/opóźnienie, pozwalając na chwilowe "bursty", o ile kubełek jest pełny. Działa to jak bufor, który gromadzi rezerwę na chwilowe skoki obciążenia, zapewniając stabilne średnie natężenie przepływu. Dodatkowo istnieje wariant Hierarchical Token Bucket w którym wiadra mogą mieć rodziców czy dzieci, który dodatkowo pozwala na "pożyczanie" tokenów od rodzica;
 - *Band steering* - w sieciach bezprzewodowych można przenosić ruch sieciowy między pasmami (np. 2.4GHz -> 5GHz) w celu uzyskania lepszej jakości usług.
 
 === Congestion control
-Mechanizm protokołu TCP dostosowywujący prędkość transmisji danych w zależności od przepustowości sieci. Operuje na tym, że w przypadku przeciążenia sieci kolejki buforów rosną co zwiększa opóźnienia i powoduje utratę pakietów. Nadawca może samodzielnie wykrywać przeciązenia i dostosowywać swoją prędkość.
+Mechanizm protokołu TCP dostosowujący prędkość transmisji danych w zależności od przepustowości sieci. Operuje na tym, że w przypadku przeciążenia sieci kolejki buforów rosną co zwiększa opóźnienia i powoduje utratę pakietów. Nadawca może samodzielnie wykrywać przeciążenia i dostosowywać swoją prędkość.
 
 Kluczowe pojęcia dla congestion control:
 - *Congestion Window* - zmienna nadawcy określająca maksymalną liczbę niepotwierdzony bajtów "w locie";


### PR DESCRIPTION
Poprawka literówek w pytaniu "Metody aktywnego zarządzania ruchem w sieciach IP."

commit 1:
- `aktynwego` → `aktywnego`
- `zarządania` → `zarządzania`

Issue: [Literówka]: (KTI) (000) Metody aktywnego zarządzania ruchem w sieciach IP

commit 2:

- `rodzciów ` → `rodziców `
- `dostosowywujący ` → `dostosowujący`
- `przeciązenia ` → `przeciążenia `

brak issue