### PR TITLE
tag w nazwach plikow w release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,6 +43,18 @@ jobs:
         with:
           name: docs
           path: docs
+
+      - name: Add version tag to filenames
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG=${GITHUB_REF#refs/tags/}
+          else
+            TAG=manual-${GITHUB_SHA}
+          fi
+          for f in docs/*.pdf; do
+            base=$(basename "$f" .pdf)
+            mv "$f" "docs/${base}-${TAG}.pdf"
+          done
       # Release for tag pushes
       - name: Create version release
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Aktualna akcja pod release powoduje, że użytkownik musi ręcznie pamiętać lub dodawać wersję do ściągniętego pliku - dodatkowy skrypt w akcji powinien to naprawić dodając tag (wersja lub SHA akcji w przypadku ręcznego uruchomienia)